### PR TITLE
Chunk requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,12 @@ jobs:
                             --format RspecJunitFormatter \
                             --out test_results/rspec.xml
       - run:
+          name: Build gem
+          command: gem build chelsea.gemspec
+      - run:
+          name: Install gem
+          command: gem install ./chelsea-*.gem
+      - run:
           name: Dogfood
           command: chelsea --file Gemfile.lock
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
                             --out test_results/rspec.xml
       - run:
           name: Dogfood
-          command: ./chelsea --file Gemfile.lock
+          command: chelsea --file Gemfile.lock
       - store_test_results:
           path: test_results
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ jobs:
             bundle exec rspec --format progress \
                             --format RspecJunitFormatter \
                             --out test_results/rspec.xml
+      - run:
+          name: Dogfood
+          command: ./chelsea --file Gemfile.lock
       - store_test_results:
           path: test_results
   release:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    chelsea (0.0.1)
-      bundler (~> 2.0.0)
+    chelsea (0.0.2)
+      bundler (>= 1.2.0, < 3)
       pastel (~> 0.7.2)
       rest-client (~> 2.0.2)
       slop (~> 4.8.0)
@@ -43,6 +43,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     slop (4.8.0)
     tty-color (0.5.1)
     tty-cursor (0.7.1)
@@ -60,6 +62,7 @@ DEPENDENCIES
   chelsea!
   rake (~> 10.0)
   rspec (~> 3.0)
+  rspec_junit_formatter (~> 0.4.1)
 
 BUNDLED WITH
    2.0.2

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Options:
 
 Most basic usage is:
 
-`chelsea --file name.gemspec`
+`chelsea --file Gemfile.lock`
 
 ## Development
 

--- a/bin/chelsea
+++ b/bin/chelsea
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
-require "chelsea"
+require_relative "../lib/chelsea"
 
 Chelsea::CLI.new.main

--- a/chelsea.gemspec
+++ b/chelsea.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-
   spec.add_dependency "tty-font", "~> 0.5.0"
   spec.add_dependency "tty-spinner", "~> 0.9.3"
   spec.add_dependency "slop", "~> 4.8.0"

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -187,7 +187,7 @@ module Chelsea
           if gran.class == String && !gran.include?(name)
             # There is likely a fun and clever way to check @server-results, etc... and see if a dep is in there
             # Right now this looks at all Ruby deps, so it might find some in your Library, but that don't belong to your project
-            puts "Required by: " + gran
+            puts "\tRequired by: " + gran
           else
           end
         end

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -157,6 +157,7 @@ module Chelsea
         if !record.nil?
           @server_response << record
         else
+          puts coord
           new_coords["coordinates"].push(coord)
         end
       end

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -175,9 +175,8 @@ module Chelsea
 
       if @coordinates["coordinates"].count() > 0
         chunked = Hash.new()
-        chunks = @coordinates["coordinates"].each_slice(128).to_a
-
-        chunks.each do |coords|
+        @coordinates["coordinates"].each_slice(128).to_a.each do |coords|
+          chunked["coordinates"] = coords
           r = RestClient.post "https://ossindex.sonatype.org/api/v3/component-report", chunked.to_json, 
           {content_type: :json, accept: :json, 'User-Agent': get_user_agent()}
         

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -35,7 +35,7 @@ module Chelsea
 
     def get_db_store_location()
       initial_path = File.join("#{Dir.home}", ".ossindex")
-      Dir.mkdir(initial_path) unless File.exists initial_path
+      Dir.mkdir(initial_path) unless File.exists? initial_path
       path = File.join(initial_path, "chelsea.pstore")
     end
 

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -152,12 +152,12 @@ module Chelsea
     # and eventually set @coordinates to the new hash, so we query OSS Index on only coords not in cache
     def check_db_for_cached_values()
       new_coords = Hash.new
+      new_coords["coordinates"] = Array.new
       @coordinates["coordinates"].each do |coord|
         record = get_cached_value_from_db(coord)
         if !record.nil?
           @server_response << record
         else
-          puts coord
           new_coords["coordinates"].push(coord)
         end
       end

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -34,7 +34,9 @@ module Chelsea
     end
 
     def get_db_store_location()
-      path = File.join("#{Dir.home}", ".ossindex", "chelsea.pstore")
+      initial_path = File.join("#{Dir.home}", ".ossindex")
+      Dir.mkdir(initial_path) unless File.exists initial_path
+      path = File.join(initial_path, "chelsea.pstore")
     end
 
     def execute(input: $stdin, output: $stdout)      

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -161,7 +161,7 @@ module Chelsea
           new_coords["coordinates"].push(coord)
         end
       end
-      @coordinates["coordinates"] = new_coords
+      @coordinates = new_coords
     end
 
     def get_vulns()
@@ -173,12 +173,11 @@ module Chelsea
 
       check_db_for_cached_values()
 
-      chunked = Hash.new()
-      chunks = @coordinates["coordinates"].each_slice(128).to_a
-      puts chunks
-      if chunks.length > 0
+      if @coordinates["coordinates"].count() > 0
+        chunked = Hash.new()
+        chunks = @coordinates["coordinates"].each_slice(128).to_a
+
         chunks.each do |coords|
-          chunked["coordinates"] = coords
           r = RestClient.post "https://ossindex.sonatype.org/api/v3/component-report", chunked.to_json, 
           {content_type: :json, accept: :json, 'User-Agent': get_user_agent()}
         

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -114,6 +114,8 @@ module Chelsea
       user_agent
     end
 
+    # This method will take an array of values, and save them to a pstore database
+    # and as well set a TTL of Time.now to be checked later
     def save_values_to_db(values)
       values.each do |val|
         if get_cached_value_from_db(val["coordinates"]).nil?

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -175,6 +175,7 @@ module Chelsea
 
       chunked = Hash.new()
       chunks = @coordinates["coordinates"].each_slice(128).to_a
+      puts chunks
       if chunks.length > 0
         chunks.each do |coords|
           chunked["coordinates"] = coords


### PR DESCRIPTION
So the first iteration of this application did not chunk requests into chunks of 128 coordinates. This PR fixes that, runs multiple requests, and reports on them.

As well, this PR now adds database cashing using `pstore`, part of the Ruby stdlib, allows you to have a file based key value store.

For caching I follow a fairly common process, coordinates are saved to the db with a key of their coordinate, and the value being the OSS Index response + a ttl of Time.now.

Before we query OSS Index, we check the DB first, and add any results that are less than 12 hours old to the server_response. Any purls it doesn't hit on are queried against, and those results are added to the cache too.

As well I've added to the CircleCI build:

- Test build of gem
- Test install of gem
- Dogfood chelsea on itself