### PR TITLE
Add quiet and format options to chelsea

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     chelsea (0.0.3)
       bundler (>= 1.2.0, < 3)
+      ox (~> 2.13.2)
       pastel (~> 0.7.2)
       rest-client (~> 2.0.2)
       slop (~> 4.8.0)
@@ -22,6 +23,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     netrc (0.11.0)
+    ox (2.13.2)
     pastel (0.7.3)
       equatable (~> 0.6)
       tty-color (~> 0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    chelsea (0.0.2)
+    chelsea (0.0.3)
       bundler (>= 1.2.0, < 3)
       pastel (~> 0.7.2)
       rest-client (~> 2.0.2)

--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ $ chelsea
  \____/|_| |_| \___||_||___/ \___| \__,_|
                                          
                                          
-Version: 0.0.1
+Version: 0.0.3
 
 usage: chelsea [options] ...
 
 Options:
-    -f, --file  do the dang thing
-    --version   print the version
+    -h, --help    show usage
+    -q, --quiet   make chelsea only output vulnerable third party dependencies for text output (default: false)
+    -t, --format  choose what type of format you want your report in (default: text) (options: text, json, xml)
+    -f, --file    path to your Gemfile.lock
+    --version     print the version
 ```
 
 Most basic usage is:

--- a/chelsea.gemspec
+++ b/chelsea.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pastel", "~> 0.7.2"
   spec.add_dependency "rest-client", "~> 2.0.2"
   spec.add_dependency "bundler", ">= 1.2.0", "< 3"
+  spec.add_dependency "ox", "~> 2.13.2"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/chelsea/cli.rb
+++ b/lib/chelsea/cli.rb
@@ -9,12 +9,13 @@ module Chelsea
       arguments = parse_arguments(command_line_options, parser)
       validate_arguments arguments
 
-      if !arguments.fetch(:quiet)
+      if !arguments.fetch(:quiet) && arguments.fetch(:format) == 'text'
         puts show_logo()
       end
 
       if arguments.fetch(:file)
-        gems(arguments[:file], {quiet: arguments[:quiet], format: arguments[:format]})
+        quiet = (arguments[:quiet] || !(arguments.fetch(:format) == 'text'))
+        gems(arguments[:file], {quiet: quiet, format: arguments[:format]})
       elsif set?(arguments, :help)
         puts cli_flags
       end

--- a/lib/chelsea/cli.rb
+++ b/lib/chelsea/cli.rb
@@ -31,9 +31,9 @@ module Chelsea
       opts.separator ""
       opts.separator 'Options:'
       opts.bool '-h', '--help', 'show usage'
-      opts.bool '-q', '--quiet', 'make chelsea only output vulnerable third party dependencies (default: false)', default: false 
-      opts.string '-t', '--format', 'choose what type of format you want your report in (default: text)', default: 'text'
-      opts.string '-f', '--file', 'do the dang thing'
+      opts.bool '-q', '--quiet', 'make chelsea only output vulnerable third party dependencies for text output (default: false)', default: false 
+      opts.string '-t', '--format', 'choose what type of format you want your report in (default: text) (options: text, json, xml)', default: 'text'
+      opts.string '-f', '--file', 'path to your Gemfile.lock'
       opts.on '--version', 'print the version' do
         puts version()
         exit

--- a/lib/chelsea/formatters/json.rb
+++ b/lib/chelsea/formatters/json.rb
@@ -6,9 +6,12 @@ module Chelsea
       @options = options
     end
 
-    def print_results(server_response, reverse_deps)
-      puts JSON.pretty_generate(server_response)
+    def get_results(server_response, reverse_deps)
+      server_response.to_json
     end
 
+    def do_print(result)
+      puts result
+    end
   end
 end

--- a/lib/chelsea/formatters/json.rb
+++ b/lib/chelsea/formatters/json.rb
@@ -1,0 +1,14 @@
+require 'json'
+
+module Chelsea
+  class JsonFormatter
+    def initialize(options)
+      @options = options
+    end
+
+    def print_results(server_response, reverse_deps)
+      puts JSON.pretty_generate(server_response)
+    end
+
+  end
+end

--- a/lib/chelsea/formatters/text.rb
+++ b/lib/chelsea/formatters/text.rb
@@ -7,11 +7,12 @@ module Chelsea
       @pastel = Pastel.new
     end
 
-    def print_results(server_response, reverse_deps)
-      if @options['quiet']
-        puts ""
-        puts "Audit Results"
-        puts "============="
+    def get_results(server_response, reverse_deps)
+      response = String.new
+      if !@options[:quiet]
+        response += "\n"\
+        "Audit Results\n"\
+        "=============\n"
       end
 
       i = 0
@@ -25,33 +26,42 @@ module Chelsea
         version = coord.split('@')[1]
         reverse_dep_coord = "#{name}-#{version}"
         if vulnerable
-          puts @pastel.red("[#{i}/#{count}] - #{package} ") +  @pastel.red.bold("Vulnerable.")
-          print_reverse_deps(reverse_deps[reverse_dep_coord], name, version)
+          response += @pastel.red("[#{i}/#{count}] - #{package} ") +  @pastel.red.bold("Vulnerable.\n")
+          response += print_reverse_deps(reverse_deps[reverse_dep_coord], name, version)
           r["vulnerabilities"].each do |k, v|
-            puts @pastel.red.bold("    #{k}:#{v}")
+            response += @pastel.red.bold("    #{k}:#{v}\n")
           end
         else
-          if @options['quiet']
-            puts(@pastel.white("[#{i}/#{count}] - #{package} ") + @pastel.green.bold("No vulnerabilities found!"))
-            print_reverse_deps(reverse_deps[reverse_dep_coord], name, version)
+          if !@options[:quiet]
+            response += @pastel.white("[#{i}/#{count}] - #{package} ") + @pastel.green.bold("No vulnerabilities found!\n")
+            response += print_reverse_deps(reverse_deps[reverse_dep_coord], name, version)
           end
         end
       end
+
+      response
+    end
+
+    def do_print(results)
+      puts results
     end
 
     private 
 
     def print_reverse_deps(reverse_deps, name, version)
+      response = String.new
       reverse_deps.each do |dep|
         dep.each do |gran|
           if gran.class == String && !gran.include?(name)
             # There is likely a fun and clever way to check @server-results, etc... and see if a dep is in there
             # Right now this looks at all Ruby deps, so it might find some in your Library, but that don't belong to your project
-            puts "\tRequired by: " + gran
+            response += "\tRequired by: #{gran}\n"
           else
           end
         end
       end
+
+      response
     end
 
   end

--- a/lib/chelsea/formatters/text.rb
+++ b/lib/chelsea/formatters/text.rb
@@ -1,0 +1,58 @@
+require 'pastel'
+
+module Chelsea
+  class TextFormatter
+    def initialize(options)
+      @options = options
+      @pastel = Pastel.new
+    end
+
+    def print_results(server_response, reverse_deps)
+      if @options['quiet']
+        puts ""
+        puts "Audit Results"
+        puts "============="
+      end
+
+      i = 0
+      count = server_response.count()
+      server_response.each do |r|
+        i += 1
+        package = r["coordinates"]
+        vulnerable = r["vulnerabilities"].length() > 0
+        coord = r["coordinates"].sub("pkg:gem/", "")
+        name = coord.split('@')[0]
+        version = coord.split('@')[1]
+        reverse_dep_coord = "#{name}-#{version}"
+        if vulnerable
+          puts @pastel.red("[#{i}/#{count}] - #{package} ") +  @pastel.red.bold("Vulnerable.")
+          print_reverse_deps(reverse_deps[reverse_dep_coord], name, version)
+          r["vulnerabilities"].each do |k, v|
+            puts @pastel.red.bold("    #{k}:#{v}")
+          end
+        else
+          if @options['quiet']
+            puts(@pastel.white("[#{i}/#{count}] - #{package} ") + @pastel.green.bold("No vulnerabilities found!"))
+            print_reverse_deps(reverse_deps[reverse_dep_coord], name, version)
+          end
+        end
+      end
+    end
+
+    private 
+
+    def print_reverse_deps(reverse_deps, name, version)
+      reverse_deps.each do |dep|
+        dep.each do |gran|
+          if gran.class == String && !gran.include?(name)
+            # There is likely a fun and clever way to check @server-results, etc... and see if a dep is in there
+            # Right now this looks at all Ruby deps, so it might find some in your Library, but that don't belong to your project
+            puts "\tRequired by: " + gran
+          else
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/lib/chelsea/formatters/xml.rb
+++ b/lib/chelsea/formatters/xml.rb
@@ -30,12 +30,11 @@ module Chelsea
           failure << coord["vulnerabilities"]
           testcase << failure
         end
-        
+
         testsuite << testcase
       end
 
-      puts Ox.dump(doc)
+      Ox.dump(doc)
     end
-
   end
 end

--- a/lib/chelsea/formatters/xml.rb
+++ b/lib/chelsea/formatters/xml.rb
@@ -1,0 +1,41 @@
+require 'ox'
+
+module Chelsea
+  class XMLFormatter
+    def initialize(options)
+      @options = options
+    end
+
+    def print_results(server_response, reverse_deps)
+      doc = Ox::Document.new
+      instruct = Ox::Instruct.new(:xml)
+      instruct[:version] = '1.0'
+      instruct[:encoding] = 'UTF-8'
+      instruct[:standalone] = 'yes'
+      doc << instruct
+
+      testsuite = Ox::Element.new('testsuite')
+      testsuite[:name] = "purl"
+      testsuite[:tests] = server_response.count()
+      doc << testsuite
+
+      server_response.each do |coord|
+        testcase = Ox::Element.new('testcase')
+        testcase[:classname] = coord["coordinates"]
+        testcase[:name] = coord["coordinates"]
+
+        if coord["vulnerabilities"].length() > 0
+          failure = Ox::Element.new('failure')
+          failure[:type] = "Vulnerable Dependency"
+          failure << coord["vulnerabilities"]
+          testcase << failure
+        end
+        
+        testsuite << testcase
+      end
+
+      puts Ox.dump(doc)
+    end
+
+  end
+end

--- a/lib/chelsea/formatters/xml.rb
+++ b/lib/chelsea/formatters/xml.rb
@@ -6,7 +6,7 @@ module Chelsea
       @options = options
     end
 
-    def print_results(server_response, reverse_deps)
+    def get_results(server_response, reverse_deps)
       doc = Ox::Document.new
       instruct = Ox::Instruct.new(:xml)
       instruct[:version] = '1.0'
@@ -27,14 +27,34 @@ module Chelsea
         if coord["vulnerabilities"].length() > 0
           failure = Ox::Element.new('failure')
           failure[:type] = "Vulnerable Dependency"
-          failure << coord["vulnerabilities"]
+          failure << get_vulnerability_block(coord["vulnerabilities"])
           testcase << failure
         end
 
         testsuite << testcase
       end
 
-      Ox.dump(doc)
+      doc
+    end
+
+    def do_print(results)
+      puts Ox.dump(results)
+    end
+
+    def get_vulnerability_block(vulnerabilities)
+      vulnBlock = String.new
+      vulnerabilities.each do |vuln|
+        vulnBlock += "Vulnerability Title: #{vuln["title"]}\n"\
+                    "ID: #{vuln["id"]}\n"\
+                    "Description: #{vuln["description"]}\n"\
+                    "CVSS Score: #{vuln["cvssScore"]}\n"\
+                    "CVSS Vector: #{vuln["cvssVector"]}\n"\
+                    "CVE: #{vuln["cve"]}\n"\
+                    "Reference: #{vuln["reference"]}"\
+                    "\n"
+      end
+      
+      vulnBlock
     end
   end
 end

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -7,6 +7,7 @@ require 'bundler/lockfile_parser'
 require_relative 'version'
 require_relative 'formatters/json'
 require_relative 'formatters/text'
+require_relative 'formatters/xml'
 require 'rubygems'
 require 'rubygems/commands/dependency_command'
 require 'pstore'
@@ -29,6 +30,8 @@ module Chelsea
         @formatter = Chelsea::TextFormatter.new(options)
       when 'json'
         @formatter = Chelsea::JsonFormatter.new(options)
+      when 'xml'
+        @formatter = Chelsea::XMLFormatter.new(options)
       else
         @formatter = Chelsea::TextFormatter.new(options)
       end

--- a/spec/unit/formatters/json_spec.rb
+++ b/spec/unit/formatters/json_spec.rb
@@ -1,0 +1,51 @@
+require 'chelsea/formatters/json'
+require 'json'
+require_relative '../test_helper'
+
+RSpec.describe Chelsea::JsonFormatter do
+  it "print_results brings back a valid json object" do
+    server_response = Array.new
+    server_response.push(populate_server_response("test", "test", "test")) 
+    server_response.push(populate_server_response("test2", "test2", "test2"))
+    server_response.push(populate_server_response_vulnerability(populate_server_response("pkg:npm/js-yaml@1.0.0", "YAML 1.2 parser and serializer", "https://ossindex.sonatype.org/component/pkg:npm/js-yaml@1.0.0")))
+    command = Chelsea::JsonFormatter.new({})
+
+    json = command.get_results(server_response, {})
+
+    expect(json.class).to eq(String)
+
+    result = JSON.parse(json)
+
+    expect(result.class).to eq(Array)
+    expect(result.count).to eq(3)
+
+    # First test object, not vulnerable
+    expect(result[0]["coordinates"]).to eq("test")
+    expect(result[0]["description"]).to eq("test")
+    expect(result[0]["reference"]).to eq("test")
+    expect(result[0]["vulnerabilities"].class).to eq(Array)
+    expect(result[0]["vulnerabilities"].count).to eq(0)
+
+    # Second test object, not vulnerable
+    expect(result[1]["coordinates"]).to eq("test2")
+    expect(result[1]["description"]).to eq("test2")
+    expect(result[1]["reference"]).to eq("test2")
+    expect(result[1]["vulnerabilities"].class).to eq(Array)
+    expect(result[1]["vulnerabilities"].count).to eq(0)
+
+    # Third test object, has vulnerability
+    expect(result[2]["coordinates"]).to eq("pkg:npm/js-yaml@1.0.0")
+    expect(result[2]["description"]).to eq("YAML 1.2 parser and serializer")
+    expect(result[2]["reference"]).to eq("https://ossindex.sonatype.org/component/pkg:npm/js-yaml@1.0.0")
+    expect(result[2]["vulnerabilities"].class).to eq(Array)
+    expect(result[2]["vulnerabilities"].count).to eq(1)
+    expect(result[2]["vulnerabilities"][0]["id"]).to eq("913ec790-8fc6-49fc-b424-170c1b60c97c")
+    expect(result[2]["vulnerabilities"][0]["title"]).to eq("[CVE-2013-4660]  Improper Input Validation")
+    # Did a length comparison because string comparison is odd here
+    expect(result[2]["vulnerabilities"][0]["description"].length).to eq(225)
+    expect(result[2]["vulnerabilities"][0]["cvssScore"]).to eq(6.8)
+    expect(result[2]["vulnerabilities"][0]["cvssVector"]).to eq("AV:N/AC:M/Au:N/C:P/I:P/A:P")
+    expect(result[2]["vulnerabilities"][0]["cve"]).to eq("CVE-2013-4660")
+    expect(result[2]["vulnerabilities"][0]["reference"]).to eq("https://ossindex.sonatype.org/vuln/913ec790-8fc6-49fc-b424-170c1b60c97c")
+  end
+end

--- a/spec/unit/formatters/xml_spec.rb
+++ b/spec/unit/formatters/xml_spec.rb
@@ -1,0 +1,24 @@
+require 'chelsea/formatters/xml'
+
+RSpec.describe Chelsea::XMLFormatter do
+  it "brings back a proper junit xml style object" do
+    server_response = Array.new
+    server_response.push(populate_server_response("test", "test", "test")) 
+    server_response.push(populate_server_response("test2", "test2", "test2")) 
+    command = Chelsea::XMLFormatter.new({})
+
+    xml = command.print_results(server_response, {})
+
+    expect(xml).to eq("")
+  end
+end
+
+def populate_server_response(coordinate, desc, reference)
+  response = Hash.new
+  response["coordinates"] = coordinate
+  response["description"] = desc
+  response["reference"] = reference
+  response["vulnerabilities"] = Array.new
+
+  response
+end

--- a/spec/unit/formatters/xml_spec.rb
+++ b/spec/unit/formatters/xml_spec.rb
@@ -1,24 +1,36 @@
 require 'chelsea/formatters/xml'
 
 RSpec.describe Chelsea::XMLFormatter do
-  it "brings back a proper junit xml style object" do
+  it "print_results brings back a Ox xml style object" do
+    expected_vuln_block = "Vulnerability Title: [CVE-2013-4660]  Improper Input Validation\n"\
+    "ID: 913ec790-8fc6-49fc-b424-170c1b60c97c\n"\
+    "Description: The JS-YAML module before 2.0.5 for Node.js parses input without properly considering the unsafe !!js/function tag, which allows remote attackers to execute arbitrary code via a crafted string that triggers an eval operation.\n"\
+    "CVSS Score: 6.8\n"\
+    "CVSS Vector: AV:N/AC:M/Au:N/C:P/I:P/A:P\n"\
+    "CVE: CVE-2013-4660\n"\
+    "Reference: https://ossindex.sonatype.org/vuln/913ec790-8fc6-49fc-b424-170c1b60c97c\n"
+
     server_response = Array.new
     server_response.push(populate_server_response("test", "test", "test")) 
-    server_response.push(populate_server_response("test2", "test2", "test2")) 
+    server_response.push(populate_server_response("test2", "test2", "test2"))
+    server_response.push(populate_server_response_vulnerability(populate_server_response("pkg:npm/js-yaml@1.0.0", "YAML 1.2 parser and serializer", "https://ossindex.sonatype.org/component/pkg:npm/js-yaml@1.0.0")))
     command = Chelsea::XMLFormatter.new({})
 
-    xml = command.print_results(server_response, {})
+    xml = command.get_results(server_response, {})
 
-    expect(xml).to eq("")
+    expect(xml.class).to eq(Ox::Document)
+
+    expect(xml.xml.attributes[:version]).to eq("1.0")
+    expect(xml.xml.attributes[:encoding]).to eq("UTF-8")
+    expect(xml.xml.attributes[:standalone]).to eq("yes")
+
+    expect(xml.testsuite.nodes.length).to eq(3)
+    expect(xml.testsuite.nodes[0].attributes[:classname]).to eq("test")
+    expect(xml.testsuite.nodes[0].attributes[:name]).to eq("test")
+    expect(xml.testsuite.nodes[1].attributes[:classname]).to eq("test2")
+    expect(xml.testsuite.nodes[1].attributes[:name]).to eq("test2")
+    expect(xml.testsuite.nodes[2].attributes[:classname]).to eq("pkg:npm/js-yaml@1.0.0")
+    expect(xml.testsuite.nodes[2].attributes[:name]).to eq("pkg:npm/js-yaml@1.0.0")
+    expect(xml.testsuite.nodes[2].nodes[0].text).to eq(expected_vuln_block)
   end
-end
-
-def populate_server_response(coordinate, desc, reference)
-  response = Hash.new
-  response["coordinates"] = coordinate
-  response["description"] = desc
-  response["reference"] = reference
-  response["vulnerabilities"] = Array.new
-
-  response
 end

--- a/spec/unit/test_helper.rb
+++ b/spec/unit/test_helper.rb
@@ -1,0 +1,23 @@
+def populate_server_response(coordinate, desc, reference)
+  response = Hash.new
+  response["coordinates"] = coordinate
+  response["description"] = desc
+  response["reference"] = reference
+  response["vulnerabilities"] = Array.new
+
+  response
+end
+
+def populate_server_response_vulnerability(server_response)
+  vulnerability = Hash.new
+  vulnerability["id"] = "913ec790-8fc6-49fc-b424-170c1b60c97c"
+  vulnerability["title"] = "[CVE-2013-4660]  Improper Input Validation"
+  vulnerability["description"] = "The JS-YAML module before 2.0.5 for Node.js parses input without properly considering the unsafe !!js/function tag, which allows remote attackers to execute arbitrary code via a crafted string that triggers an eval operation."
+  vulnerability["cvssScore"] = 6.8
+  vulnerability["cvssVector"] = "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+  vulnerability["cve"] = "CVE-2013-4660"
+  vulnerability["reference"] = "https://ossindex.sonatype.org/vuln/913ec790-8fc6-49fc-b424-170c1b60c97c"
+  server_response["vulnerabilities"].push(vulnerability)
+  
+  server_response
+end


### PR DESCRIPTION
Pretty much all the other OSS Index integrations have:

- Quiet option (squelch all non essential output, header, etc...)
- Ability to pick a format for output

Quiet implemented for all formatters, primarily for text formatter, but also for junit/xml such that only that gets spit out (for someone using chelsea to output to a file)

XML, Json and text formatters implemented/refactored

Tests added for XML and json (net new). Text refactored to follow their pattern as well, no test yet (will write as a part of another PR)