### PR TITLE
Initial OSS Index Config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    chelsea (0.0.3)
+    chelsea (0.0.6)
       bundler (>= 1.2.0, < 3)
       ox (~> 2.13.2)
       pastel (~> 0.7.2)

--- a/bin/chelsea
+++ b/bin/chelsea
@@ -6,8 +6,9 @@ opts =
   begin
     Slop.parse do |o|
       o.string '-f', '--file', 'path to your Gemfile.lock'
-      o.string '-u', '--user', 'Specify OSS Index Username'
-      o.string '-p', '--token', 'Specify OSS Index API Token'
+      o.bool '-c', '--config', 'Set persistent config for OSS Index'
+      o.string '-u', '--user', 'Specify OSS Index Username', default: ""
+      o.string '-p', '--token', 'Specify OSS Index API Token', default: ""
       o.string '-w', '--whitelist', 'Set path to vulnerability whitelist file'
       o.bool '-q', '--quiet', 'make chelsea only output vulnerable third party dependencies for text output (default: false)', default: false 
       o.string '-t', '--format', 'choose what type of format you want your report in (default: text) (options: text, json, xml)', default: 'text'

--- a/bin/chelsea
+++ b/bin/chelsea
@@ -7,7 +7,7 @@ opts =
     Slop.parse do |o|
       o.string '-f', '--file', 'path to your Gemfile.lock'
       o.string '-u', '--user', 'Specify OSS Index Username'
-      o.string '-t', '--token', 'Specify OSS Index API Token'
+      o.string '-p', '--token', 'Specify OSS Index API Token'
       o.string '-w', '--whitelist', 'Set path to vulnerability whitelist file'
       o.bool '-q', '--quiet', 'make chelsea only output vulnerable third party dependencies for text output (default: false)', default: false 
       o.string '-t', '--format', 'choose what type of format you want your report in (default: text) (options: text, json, xml)', default: 'text'

--- a/bin/chelsea
+++ b/bin/chelsea
@@ -6,6 +6,9 @@ opts =
   begin
     Slop.parse do |o|
       o.string '-f', '--file', 'path to your Gemfile.lock'
+      o.string '-u', '--user', 'Specify OSS Index Username'
+      o.string '-t', '--token', 'Specify OSS Index API Token'
+      o.string '-w', '--whitelist', 'Set path to vulnerability whitelist file'
       o.bool '-q', '--quiet', 'make chelsea only output vulnerable third party dependencies for text output (default: false)', default: false 
       o.string '-t', '--format', 'choose what type of format you want your report in (default: text) (options: text, json, xml)', default: 'text'
       o.on '--version', 'print the version' do

--- a/lib/chelsea/cli.rb
+++ b/lib/chelsea/cli.rb
@@ -19,7 +19,7 @@ module Chelsea
 
     def process!
       if @opts.file?
-        @gems = Chelsea::Gems.new(file: @opts[:file], @opts)
+        @gems = Chelsea::Gems.new(file: @opts[:file], quiet: false, options: @opts)
         @gems.execute
       elsif @opts.help?
         puts _cli_flags
@@ -40,6 +40,8 @@ module Chelsea
       opts.separator ""
       opts.separator 'Options:'
       opts.bool '-h', '--help', 'show usage'
+      opts.string '-u', '--user', 'Specify OSS Index Username'
+      opts.string '-p', '--token', 'Specify OSS Index API Token'
       opts.bool '-q', '--quiet', 'make chelsea only output vulnerable third party dependencies for text output (default: false)', default: false 
       opts.string '-t', '--format', 'choose what type of format you want your report in (default: text) (options: text, json, xml)', default: 'text'
       opts.string '-f', '--file', 'path to your Gemfile.lock'

--- a/lib/chelsea/cli.rb
+++ b/lib/chelsea/cli.rb
@@ -4,6 +4,7 @@ require 'tty-font'
 
 require_relative 'version'
 require_relative 'gems'
+require_relative 'config'
 
 module Chelsea
   ##
@@ -18,11 +19,12 @@ module Chelsea
     end
 
     def process!
+      if @opts.config?
+        _try_set_config()
+      end
       if @opts.file?
         @gems = Chelsea::Gems.new(file: @opts[:file], quiet: false, options: @opts)
         @gems.execute
-      elsif @opts.help?
-        puts _cli_flags
       end
     end
 
@@ -34,30 +36,10 @@ module Chelsea
 
   protected
 
-    def _cli_flags
-      opts = Slop::Options.new
-      opts.banner = "usage: chelsea [options] ..."
-      opts.separator ""
-      opts.separator 'Options:'
-      opts.bool '-h', '--help', 'show usage'
-      opts.string '-u', '--user', 'Specify OSS Index Username'
-      opts.string '-p', '--token', 'Specify OSS Index API Token'
-      opts.bool '-q', '--quiet', 'make chelsea only output vulnerable third party dependencies for text output (default: false)', default: false 
-      opts.string '-t', '--format', 'choose what type of format you want your report in (default: text) (options: text, json, xml)', default: 'text'
-      opts.string '-f', '--file', 'path to your Gemfile.lock'
-      opts.on '--version', 'print the version' do
-        puts version()
-        exit
-      end
-
-      opts
-    end
-
     def _flags_error
       # should be custom exception! 
       switches = _flags.collect {|f| "--#{f}"}
-      puts _cli_flags
-      puts
+
       abort "please set one of #{switches}"
     end
 
@@ -76,7 +58,7 @@ module Chelsea
 
     def _flags
       # Seems wrong, should all be handled by bin
-      [:file, :help]
+      [:file, :help, :config]
     end
 
     def _show_logo()
@@ -88,6 +70,11 @@ module Chelsea
     def _try_load_config()
       config = Chelsea::Config.new
       oss_index_config = config.get_oss_index_config()
+    end
+
+    def _try_set_config()
+      config = Chelsea::Config.new
+      config.get_oss_index_config_from_command_line()
     end
   end
 end

--- a/lib/chelsea/cli.rb
+++ b/lib/chelsea/cli.rb
@@ -19,11 +19,10 @@ module Chelsea
 
     def process!
       if @opts.file?
-        @gems = Chelsea::Gems.new(file: @opts[:file])
+        @gems = Chelsea::Gems.new(file: @opts[:file], @opts)
         @gems.execute
       elsif @opts.help?
         puts _cli_flags
-
       end
     end
 
@@ -82,6 +81,11 @@ module Chelsea
       font = TTY::Font.new(:doom)
       puts @pastel.green(font.write("Chelsea"))
       puts @pastel.green("Version: " + CLI::version)
+    end
+
+    def _try_load_config()
+      config = Chelsea::Config.new
+      oss_index_config = config.get_oss_index_config()
     end
   end
 end

--- a/lib/chelsea/config.rb
+++ b/lib/chelsea/config.rb
@@ -3,17 +3,17 @@ require 'yaml'
 module Chelsea
   class Config
     def initialize(opts = {})
-      @@oss_index_config_location = File.join("#{Dir.home}", ".ossindex")
-      @@oss_index_config_filename = ".oss-index-config"
+      @oss_index_config_location = File.join("#{Dir.home}", ".ossindex")
+      @oss_index_config_filename = ".oss-index-config"
     end
 
     def get_oss_index_config()
-      oss_index_config = YAML.load(File.read(File.join(@@oss_index_config_location, @@oss_index_config_filename)))
+      oss_index_config = YAML.load(File.read(File.join(@oss_index_config_location, @oss_index_config_filename)))
 
       oss_index_config
     end
 
-    def self.get_white_list_vuln_config(white_list_config_path)
+    def get_white_list_vuln_config(white_list_config_path)
       if white_list_config_path.nil?
         white_list_vuln_config = YAML.load(File.read(File.join(Dir.pwd, "chelsea-ignore.yaml")))
       else
@@ -26,13 +26,11 @@ module Chelsea
     def get_oss_index_config_from_command_line()
       config = {}
 
-      puts "What username do you want to authenticate as (ex: your email address)?"
-      config["Username"] = gets
-      config["Username"] = config["Username"].chomp
+      puts "What username do you want to authenticate as (ex: your email address)? "
+      config["Username"] = STDIN.gets.chomp
 
-      puts "What token do you want to use?"
-      config["Token"] = gets
-      config["Token"] = config["Token"].chomp
+      puts "What token do you want to use? "
+      config["Token"] = STDIN.gets.chomp
 
       _set_oss_index_config(config)
     end
@@ -40,9 +38,9 @@ module Chelsea
     private
 
       def _set_oss_index_config(config)
-        Dir.mkdir(@@oss_index_config_location) unless File.exists? @@oss_index_config_location
+        Dir.mkdir(@oss_index_config_location) unless File.exists? @oss_index_config_location
 
-        File.open(File.join(@@oss_index_config_location, @@oss_index_config_filename), "w") do |file|
+        File.open(File.join(@oss_index_config_location, @oss_index_config_filename), "w") do |file|
           file.write config.to_yaml
         end
       end

--- a/lib/chelsea/config.rb
+++ b/lib/chelsea/config.rb
@@ -1,0 +1,51 @@
+require 'yaml'
+
+module Chelsea
+  class Config
+    def initialize(opts = {})
+      @@oss_index_config_location = File.join("#{Dir.home}", ".ossindex")
+      @@oss_index_config_filename = ".oss-index-config"
+    end
+
+    def get_oss_index_config()
+      oss_index_config = YAML.load(File.read(File.join(@@oss_index_config_location, @@oss_index_config_filename)))
+
+      oss_index_config
+    end
+
+    def self.get_white_list_vuln_config(white_list_config_path)
+      if white_list_config_path.nil?
+        white_list_vuln_config = YAML.load(File.read(File.join(Dir.pwd, "chelsea-ignore.yaml")))
+      else
+        white_list_vuln_config = YAML.load(File.read(white_list_config_path))
+      end
+
+      white_list_vuln_config
+    end
+
+    def get_oss_index_config_from_command_line()
+      config = {}
+
+      puts "What username do you want to authenticate as (ex: your email address)?"
+      config["Username"] = gets
+      config["Username"] = config["Username"].chomp
+
+      puts "What token do you want to use?"
+      config["Token"] = gets
+      config["Token"] = config["Token"].chomp
+
+      _set_oss_index_config(config)
+    end
+
+    private
+
+      def _set_oss_index_config(config)
+        Dir.mkdir(@@oss_index_config_location) unless File.exists? @@oss_index_config_location
+
+        File.open(File.join(@@oss_index_config_location, @@oss_index_config_filename), "w") do |file|
+          file.write config.to_yaml
+        end
+      end
+
+  end
+end

--- a/lib/chelsea/config.rb
+++ b/lib/chelsea/config.rb
@@ -8,9 +8,13 @@ module Chelsea
     end
 
     def get_oss_index_config()
-      oss_index_config = YAML.load(File.read(File.join(@oss_index_config_location, @oss_index_config_filename)))
+      if !File.exist? File.join(@oss_index_config_location, @oss_index_config_filename)
+        return {}
+      else
+        oss_index_config = YAML.load(File.read(File.join(@oss_index_config_location, @oss_index_config_filename)))
 
-      oss_index_config
+        oss_index_config
+      end
     end
 
     def get_white_list_vuln_config(white_list_config_path)

--- a/lib/chelsea/deps.rb
+++ b/lib/chelsea/deps.rb
@@ -102,14 +102,8 @@ module Chelsea
           if r.code == 200
             @server_response = @server_response.concat(JSON.parse(r.body))
             _save_values_to_db(JSON.parse(r.body))
-            @server_response.count()
-          else
-            0
           end
         end
-      else
-        #IDGI
-        @server_response.count()
       end
     end
 

--- a/lib/chelsea/deps.rb
+++ b/lib/chelsea/deps.rb
@@ -2,16 +2,19 @@ require 'bundler'
 require 'bundler/lockfile_parser'
 require 'rubygems'
 require 'rubygems/commands/dependency_command'
-require_relative 'dependency_exception'
 require 'json'
 require 'rest-client'
 require 'pstore'
+
+require_relative 'dependency_exception'
+require_relative 'oss_index'
 
 module Chelsea
   class Deps
     attr_reader :server_response, :reverse_dependencies, :coordinates, :dependencies
 
-    def initialize(path: , quiet: false)
+    def initialize(path: , oss_index_client: , quiet: false)
+      @oss_index_client = oss_index_client
       @path, @quiet = path, quiet
       ENV['BUNDLE_GEMFILE'] = File.expand_path(path).chomp(".lock")
 
@@ -37,10 +40,6 @@ module Chelsea
 
     def self.to_purl(name, version)
       return "pkg:gem/#{name}@#{version}"
-    end
-
-    def user_agent
-      "chelsea/#{Chelsea::VERSION}"
     end
 
     # Parses specs from lockfile instanct var and inserts into dependenices instance var
@@ -93,12 +92,9 @@ module Chelsea
         chunked = Hash.new()
         @coordinates["coordinates"].each_slice(128).to_a.each do |coords|
           chunked["coordinates"] = coords
-          r = RestClient.post "https://ossindex.sonatype.org/api/v3/component-report", chunked.to_json,
-            { content_type: :json, accept: :json, 'User-Agent': user_agent }
-          if r.code == 200
-            @server_response = @server_response.concat(JSON.parse(r.body))
-            _save_values_to_db(JSON.parse(r.body))
-          end
+          res_json = @oss_index_client.call_oss_index(chunked)
+          @server_response = @server_response.concat(res_json)
+          _save_values_to_db(res_json)
         end
       end
     end

--- a/lib/chelsea/formatters/factory.rb
+++ b/lib/chelsea/formatters/factory.rb
@@ -6,11 +6,11 @@ class FormatterFactory
     def get_formatter(format: 'text', options: {})
         case format
         when 'text'
-          Chelsea::TextFormatter.new(options)
+          Chelsea::TextFormatter.new()
         when 'json'
-          Chelsea::JsonFormatter.new(options)
+          Chelsea::JsonFormatter.new()
         when 'xml'
-          Chelsea::XMLFormatter.new(options)
+          Chelsea::XMLFormatter.new()
         end
   end
 end

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -20,7 +20,7 @@ module Chelsea
         raise "Gemfile.lock not found, check --file path"
       end
       @pastel = Pastel.new
-      @formatter = FormatterFactory.new.get_formatter(@options)
+      @formatter = FormatterFactory.new.get_formatter(format: @options[:format], options: @options)
       @deps = Chelsea::Deps.new({path: Pathname.new(@file)})
     end
 
@@ -34,8 +34,8 @@ module Chelsea
         _print_err "No vulnerability data retrieved from server. Exiting."
         return
       end
-      if @options[:whitelist]?
-        
+      if !@options[:whitelist]
+        puts "Hello"
       end
       @formatter.do_print(@formatter.get_results(@deps))
     end

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -21,7 +21,7 @@ module Chelsea
       end
       @pastel = Pastel.new
       @formatter = FormatterFactory.new.get_formatter(format: @options[:format], options: @options)
-      @deps = Chelsea::Deps.new({path: Pathname.new(@file)})
+      @deps = Chelsea::Deps.new({path: Pathname.new(@file), oss_index_client: Chelsea::OSSIndex.new(oss_index_user_name: @options[:user], oss_index_user_token: @options[:token])})
     end
 
     # Audits depenencies using deps library and prints results
@@ -36,9 +36,9 @@ module Chelsea
         _print_err "No vulnerability data retrieved from server. Exiting."
         return
       end
-      if !@options[:whitelist]
-        puts "Hello"
-      end
+      # if !@options[:whitelist]
+
+      # end
       @formatter.do_print(@formatter.get_results(@deps))
     end
 
@@ -51,6 +51,9 @@ module Chelsea
 
       begin
         @deps.get_dependencies
+        unless @quiet
+          spinner.success("...done.")
+        end
       rescue StandardError => e
         unless @quiet
           spinner.stop
@@ -74,6 +77,9 @@ module Chelsea
 
       begin
         @deps.get_vulns
+        unless @quiet
+          spinner.success("...done.")
+        end
       rescue SocketError => e
         unless @quiet
           spinner.stop("...request failed.")

--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -34,6 +34,9 @@ module Chelsea
         _print_err "No vulnerability data retrieved from server. Exiting."
         return
       end
+      if @options[:whitelist]?
+        
+      end
       @formatter.do_print(@formatter.get_results(@deps))
     end
 

--- a/lib/chelsea/oss_index.rb
+++ b/lib/chelsea/oss_index.rb
@@ -1,0 +1,46 @@
+require_relative 'config'
+require 'rest-client'
+
+module Chelsea
+  class OSSIndex
+    
+    def initialize(oss_index_user_name: "", oss_index_user_token: "")
+      if oss_index_user_name.empty? || oss_index_user_token.empty?
+        config = Chelsea::Config.new().get_oss_index_config()
+        @oss_index_user_name, @oss_index_user_token = config["Username"], config["Token"]
+      else
+        @oss_index_user_name, @oss_index_user_token = oss_index_user_name, oss_index_user_token
+      end
+    end
+
+    def call_oss_index(coords)
+      r = _resource.post coords.to_json, _headers
+      if r.code == 200
+        JSON.parse(r.body)
+      end
+    end
+
+    private
+
+    def _headers
+      { :content_type => :json, :accept => :json, 'User-Agent' => _user_agent }
+    end
+
+    def _resource
+      if !@oss_index_user_name.empty? && !@oss_index_user_token.empty?
+        RestClient::Resource.new _api_url, :user => @oss_index_user_name, :password => @oss_index_user_token
+      else
+        RestClient::Resource.new _api_url
+      end
+    end
+
+    def _api_url
+      "https://ossindex.sonatype.org/api/v3/component-report"
+    end
+
+    def _user_agent
+      "chelsea/#{Chelsea::VERSION}"
+    end
+
+  end
+end

--- a/lib/chelsea/oss_index.rb
+++ b/lib/chelsea/oss_index.rb
@@ -7,7 +7,7 @@ module Chelsea
     def initialize(oss_index_user_name: "", oss_index_user_token: "")
       if oss_index_user_name.empty? || oss_index_user_token.empty?
         config = Chelsea::Config.new().get_oss_index_config()
-        if config == {}
+        if config != {}
           @oss_index_user_name, @oss_index_user_token = config["Username"], config["Token"]
         else
           @oss_index_user_name, @oss_index_user_token = oss_index_user_name, oss_index_user_token

--- a/lib/chelsea/oss_index.rb
+++ b/lib/chelsea/oss_index.rb
@@ -7,7 +7,7 @@ module Chelsea
     def initialize(oss_index_user_name: "", oss_index_user_token: "")
       if oss_index_user_name.empty? || oss_index_user_token.empty?
         config = Chelsea::Config.new().get_oss_index_config()
-        if config.empty?
+        if config == {}
           @oss_index_user_name, @oss_index_user_token = config["Username"], config["Token"]
         else
           @oss_index_user_name, @oss_index_user_token = oss_index_user_name, oss_index_user_token

--- a/lib/chelsea/oss_index.rb
+++ b/lib/chelsea/oss_index.rb
@@ -3,11 +3,15 @@ require 'rest-client'
 
 module Chelsea
   class OSSIndex
-    
+
     def initialize(oss_index_user_name: "", oss_index_user_token: "")
       if oss_index_user_name.empty? || oss_index_user_token.empty?
         config = Chelsea::Config.new().get_oss_index_config()
-        @oss_index_user_name, @oss_index_user_token = config["Username"], config["Token"]
+        if config.empty?
+          @oss_index_user_name, @oss_index_user_token = config["Username"], config["Token"]
+        else
+          @oss_index_user_name, @oss_index_user_token = oss_index_user_name, oss_index_user_token
+        end
       else
         @oss_index_user_name, @oss_index_user_token = oss_index_user_name, oss_index_user_token
       end

--- a/spec/unit/deps_spec.rb
+++ b/spec/unit/deps_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Chelsea::Deps do
        'User-Agent'=>'chelsea/0.0.3'
      }).to_return(status: 200, body: OSS_INDEX_RESPONSE, headers: {})
 
-    deps = Chelsea::Deps.new({path: Pathname.new(file)})
+    deps = Chelsea::Deps.new({path: Pathname.new(file), oss_index_client: Chelsea::OSSIndex.new()})
     deps.get_dependencies
     deps.get_reverse_dependencies
     deps.get_dependencies_versions_as_coordinates
@@ -43,7 +43,7 @@ RSpec.describe Chelsea::Deps do
             'Host'=>'ossindex.sonatype.org',
             'User-Agent'=>'chelsea/0.0.3'
           }).to_return(status: 200, body: OSS_INDEX_RESPONSE, headers: {})
-    deps = Chelsea::Deps.new({path: Pathname.new(file)})
+    deps = Chelsea::Deps.new({path: Pathname.new(file), oss_index_client: Chelsea::OSSIndex.new()})
     deps.get_dependencies
     deps.get_reverse_dependencies
     deps.get_dependencies_versions_as_coordinates
@@ -61,7 +61,7 @@ RSpec.describe Chelsea::Deps do
   it "will raises a RuntimeError with a custom message with an invalid file path" do
     output = StringIO.new
     file = "invalid/path"
-    expect{Chelsea::Deps.new({path: Pathname.new(file)})}.to raise_error(RuntimeError, "Gemfile.lock not parseable, please check file or that it's path is valid")
+    expect{Chelsea::Deps.new({path: Pathname.new(file), oss_index_client: Chelsea::OSSIndex.new()})}.to raise_error(RuntimeError, "Gemfile.lock not parseable, please check file or that it's path is valid")
   end
 
   it "can turn a name and version into a valid purl" do

--- a/spec/unit/gems_spec.rb
+++ b/spec/unit/gems_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Chelsea::Gems do
     it "can collect dependencies, query, and print results" do
       output = StringIO.new
       file = "spec/testdata/Gemfile.lock"
-      command = Chelsea::Gems.new(file: file)
+      command = Chelsea::Gems.new(file: file, options: { :user => "", :token => "", :format => 'text' })
 
       command.execute(output: output)
 


### PR DESCRIPTION
This PR adds:

- `config.rb` which is responsible for getting and setting config (whitelist config added just for illustration)
- Changes to `deps.rb` to break `oss_index` into it's own client class, so we can a) inject it where we need to, and also set it's config easier

Adds a `--config` option to Chelsea which allows you to set your config

Checks for command line flags for `--user` and `--token` and gives those priority over persistent config, and only loads persistent config if one is set to empty