### PR TITLE
tighetend formatter defaults

### DIFF
--- a/lib/chelsea/gems.rb
+++ b/lib/chelsea/gems.rb
@@ -14,7 +14,7 @@ require_relative 'bom'
 module Chelsea
   class Gems
     attr_accessor :deps
-    def initialize(file:, quiet: false, options: {})
+    def initialize(file:, quiet: false, options: {'format': 'text'})
       @quiet = quiet
       unless File.file?(file) || file.nil?
         raise 'Gemfile.lock not found, check --file path'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,7 @@ def get_test_dependencies
   deps.dependencies
 end
 
-def get_coordinates()
+def get_coordinates
   coordinates = Hash.new
   coordinates["coordinates"] = Array.new
   coordinates["coordinates"] << "pkg:gem/chelsea@0.0.3"

--- a/spec/unit/iq_client_spec.rb
+++ b/spec/unit/iq_client_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Chelsea::IQClient do
     context 'with an generated dependencies sbom' do
       it 'should be able to submit an sbom' do
         deps = get_test_dependencies
-        bom = Chelsea::Bom.new(deps)  
+        bom = Chelsea::Bom.new(deps)
       end
     end
     # Check that defaults get set


### PR DESCRIPTION
Gem tests were breaking 
`) Chelsea::Gems when talking to OSS Index given a valid Gemfile.lock can collect dependencies, query, and print results
     Failure/Error: expect { command.execute }.to_not raise_error
     
       expected no Exception, got #<NoMethodError: undefined method `each_with_object' for #<Proc:0x000055c9cfa0fe58>> with backtrace:`