### PR TITLE
Add configurable OSS Index server URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ usage: /usr/local/bin/chelsea [options]
     -c, --config       Set persistent config for OSS Index
     -u, --user         Specify OSS Index Username
     -p, --token        Specify OSS Index API Token
+    -o, --ossindex-url Specify OSS Index server URL
     -a, --application  Specify the IQ application id
     -i, --server       Specify the IQ server url
     -iu, --iquser      Specify the IQ username
@@ -104,7 +105,30 @@ Chelsea will cache results from OSS Index, preventing Rate Limiting to occur in 
 
 `chelsea --config`
 
-Chelsea will prompt you to save your config, provide your username (email address that you registered on OSS Index with), and API Token, save those, and voila! Your rate limiting should be sufficient for most use cases at this point. If it isn't, get in touch via our GitHub issues, and we can take a look at your use case and potentially partner!
+Chelsea will prompt you to save your config, provide your username (email address that you registered on OSS Index with), API Token, and optionally a custom OSS Index server URL. Save those, and voila! Your rate limiting should be sufficient for most use cases at this point. If it isn't, get in touch via our GitHub issues, and we can take a look at your use case and potentially partner!
+
+### Using a Custom OSS Index Server URL
+
+If you need to use a custom or on-premises OSS Index server, you can specify the server URL in several ways:
+
+#### Via Command Line
+
+You can specify the OSS Index server URL directly on the command line:
+
+`chelsea --file Gemfile.lock --ossindex-url https://custom.ossindex.example.com`
+
+You can combine this with authentication credentials:
+
+`chelsea --file Gemfile.lock --ossindex-url https://custom.ossindex.example.com --user your@email.com --token your-api-token`
+
+#### Via Configuration File
+
+When setting up your persistent configuration using `chelsea --config`, you will be prompted to enter:
+1. Your username (email address)
+2. Your API token
+3. Your OSS Index server URL (defaults to https://ossindex.sonatype.org if left blank)
+
+This configuration is saved to `~/.ossindex/.oss-index-config` for future use.
 
 ### Usage with Nexus IQ Server
 

--- a/bin/chelsea
+++ b/bin/chelsea
@@ -27,6 +27,7 @@ opts =
       o.bool '-c', '--config', 'Set persistent config for OSS Index'
       o.string '-u', '--user', 'Specify OSS Index Username'
       o.string '-p', '--token', 'Specify OSS Index API Token'
+      o.string '-o', '--ossindex-url', 'Specify OSS Index server URL', default: 'https://ossindex.sonatype.org'
       o.string '-a', '--application', 'Specify the IQ application id', default: 'testapp'
       o.string '-i', '--server', 'Specify the IQ server url', default: 'http://localhost:8070'
       o.string '-iu', '--iquser', 'Specify the IQ username', default: 'admin'

--- a/lib/chelsea/config.rb
+++ b/lib/chelsea/config.rb
@@ -33,11 +33,14 @@ module Chelsea
       Chelsea::OSSIndex.new(
         options: {
           oss_index_user_name: options[:user],
-          oss_index_user_token: options[:token]
+          oss_index_user_token: options[:token],
+          oss_index_url: options[:ossindex_url]
         }
       )
     else
-      Chelsea::OSSIndex.new(options: oss_index_config)
+      config_opts = oss_index_config
+      config_opts[:oss_index_url] = options[:ossindex_url] unless options[:ossindex_url].nil?
+      Chelsea::OSSIndex.new(options: config_opts)
     end
   end
 
@@ -55,10 +58,11 @@ module Chelsea
       )
       {
         oss_index_user_name: conf_hash['Username'],
-        oss_index_user_token: conf_hash['Token']
+        oss_index_user_token: conf_hash['Token'],
+        oss_index_url: conf_hash['OSSIndexUrl'] || 'https://ossindex.sonatype.org'
       }
     else
-      { oss_index_user_name: '', oss_index_user_token: '' }
+      { oss_index_user_name: '', oss_index_user_token: '', oss_index_url: 'https://ossindex.sonatype.org' }
     end
   end
 
@@ -78,6 +82,10 @@ module Chelsea
 
     puts 'What token do you want to use? '
     config['Token'] = $stdin.gets.chomp
+
+    puts 'What OSS Index URL do you want to use? (default: https://ossindex.sonatype.org) '
+    url_input = $stdin.gets.chomp
+    config['OSSIndexUrl'] = url_input.empty? ? 'https://ossindex.sonatype.org' : url_input
 
     _write_oss_index_config_file(config)
   end

--- a/lib/chelsea/oss_index.rb
+++ b/lib/chelsea/oss_index.rb
@@ -25,11 +25,13 @@ module Chelsea
   class OSSIndex
     DEFAULT_OPTIONS = {
       oss_index_username: '',
-      oss_index_user_token: ''
+      oss_index_user_token: '',
+      oss_index_url: 'https://ossindex.sonatype.org'
     }.freeze
     def initialize(options: DEFAULT_OPTIONS)
       @oss_index_user_name = options[:oss_index_user_name]
       @oss_index_user_token = options[:oss_index_user_token]
+      @oss_index_url = options[:oss_index_url] || DEFAULT_OPTIONS[:oss_index_url]
       @db = DB.new
     end
 
@@ -87,7 +89,7 @@ module Chelsea
     end
 
     def _api_url
-      'https://ossindex.sonatype.org/api/v3/component-report'
+      "#{@oss_index_url}/api/v3/component-report"
     end
 
     def _user_agent

--- a/spec/unit/oss_index_spec.rb
+++ b/spec/unit/oss_index_spec.rb
@@ -27,8 +27,89 @@ RSpec.describe Chelsea::OSSIndex do
     it 'should instantiate the OSS Index client' do
       expect(@oss.class).to eq Chelsea::OSSIndex
     end
-    # Check that defaults get set
+    it 'should use default OSS Index URL' do
+      expect(@oss.send(:_api_url)).to eq 'https://ossindex.sonatype.org/api/v3/component-report'
+    end
   end
+
+  context 'with custom OSS Index URL' do
+    before(:all) do
+      @custom_url = 'https://custom.ossindex.example.com'
+      @oss = Chelsea::OSSIndex.new(
+        options: {
+          oss_index_user_name: '',
+          oss_index_user_token: '',
+          oss_index_url: @custom_url
+        }
+      )
+    end
+
+    it 'should use custom OSS Index URL' do
+      expect(@oss.send(:_api_url)).to eq "#{@custom_url}/api/v3/component-report"
+    end
+
+    it 'should make request to custom URL' do
+      coordinates = { 'coordinates' => ['pkg:gem/test@1.0.0'] }
+      stub_request(:post, "#{@custom_url}/api/v3/component-report")
+        .to_return(status: 200, body: '[]', headers: { 'Content-Type' => 'application/json' })
+
+      @oss.call_oss_index(coordinates)
+
+      expect(
+        a_request(:post, "#{@custom_url}/api/v3/component-report")
+      ).to have_been_made.once
+    end
+  end
+
+  context 'with custom OSS Index URL and credentials' do
+    before(:all) do
+      @custom_url = 'https://secure.ossindex.example.com'
+      @username = 'test@example.com'
+      @token = 'test-token-123'
+      @oss = Chelsea::OSSIndex.new(
+        options: {
+          oss_index_user_name: @username,
+          oss_index_user_token: @token,
+          oss_index_url: @custom_url
+        }
+      )
+    end
+
+    it 'should use custom OSS Index URL with authentication' do
+      expect(@oss.send(:_api_url)).to eq "#{@custom_url}/api/v3/component-report"
+    end
+
+    it 'should make authenticated request to custom URL' do
+      coordinates = { 'coordinates' => ['pkg:gem/test@1.0.0'] }
+      stub_request(:post, "#{@custom_url}/api/v3/component-report")
+        .with(basic_auth: [@username, @token])
+        .to_return(status: 200, body: '[]', headers: { 'Content-Type' => 'application/json' })
+
+      @oss.call_oss_index(coordinates)
+
+      expect(
+        a_request(:post, "#{@custom_url}/api/v3/component-report")
+          .with(basic_auth: [@username, @token])
+      ).to have_been_made.once
+    end
+  end
+
+  context 'with nil OSS Index URL (should fallback to default)' do
+    before(:all) do
+      @oss = Chelsea::OSSIndex.new(
+        options: {
+          oss_index_user_name: '',
+          oss_index_user_token: '',
+          oss_index_url: nil
+        }
+      )
+    end
+
+    it 'should fallback to default OSS Index URL' do
+      expect(@oss.send(:_api_url)).to eq 'https://ossindex.sonatype.org/api/v3/component-report'
+    end
+  end
+
   context 'with cli arguments' do
     # Check that cli args get set
   end


### PR DESCRIPTION
## Summary
This PR adds the ability for users to configure a custom OSS Index server URL, enabling support for on-premises or alternative OSS Index instances. This feature follows the same pattern used for IQ server URL configuration.

## Changes
- **CLI**: Added `--ossindex-url` option to specify custom OSS Index server URL
- **OSSIndex class**: Modified to accept and use configurable URL instead of hardcoded value
- **Configuration**: Updated config system to persist OSS Index URL in `~/.ossindex/.oss-index-config`
- **Interactive setup**: Added prompt for OSS Index URL during `chelsea --config`
- **Tests**: Added comprehensive test coverage for all URL configuration scenarios
- **Documentation**: Updated README with usage examples for command-line and configuration file usage

## Usage Examples

### Command Line
```bash
chelsea --file Gemfile.lock --ossindex-url https://custom.ossindex.example.com
```

### With Authentication
```bash
chelsea --file Gemfile.lock --ossindex-url https://custom.ossindex.example.com --user your@email.com --token your-api-token
```

### Persistent Configuration
```bash
chelsea --config
# Will prompt for username, token, and OSS Index URL
```

## Test Plan
- [x] Syntax validation passed for all modified Ruby files
- [x] Added unit tests covering:
  - Default URL behavior
  - Custom URL configuration
  - Custom URL with authentication credentials
  - Nil URL fallback to default
- [ ] Full test suite execution (requires proper Ruby/bundler environment)
- [ ] Manual testing with actual OSS Index server
- [ ] Verify backward compatibility (existing configs without URL field)

## Backward Compatibility
- Default behavior unchanged (uses `https://ossindex.sonatype.org`)
- Existing config files without `OSSIndexUrl` field will use default
- No breaking changes to existing functionality

## Related
This implementation mirrors the pattern used for IQ server URL configuration (`--server` option), ensuring consistency across the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)