### PR TITLE
fix(security): Address critical vulnerabilities including RCE

### DIFF
--- a/lib/chelsea/config.rb
+++ b/lib/chelsea/config.rb
@@ -17,6 +17,7 @@
 #
 
 require 'yaml'
+require 'io/console'
 require_relative 'oss_index'
 
 # Saved credentials
@@ -76,16 +77,29 @@ module Chelsea
     puts 'What username do you want to authenticate as (ex: your email address)? '
     config['Username'] = $stdin.gets.chomp
 
+    # SECURITY: Mask token input to prevent shoulder surfing
     puts 'What token do you want to use? '
-    config['Token'] = $stdin.gets.chomp
+    config['Token'] = $stdin.noecho(&:gets).chomp
+    puts '' # Add newline after hidden input
 
     _write_oss_index_config_file(config)
   end
 
   def self._write_oss_index_config_file(config)
-    Dir.mkdir(@oss_index_config_location) unless File.exist? @oss_index_config_location
-    File.open(File.join(@oss_index_config_location, @oss_index_config_filename), 'w') do |file|
+    # SECURITY: Create directory with restrictive permissions (CWE-732)
+    unless File.exist? @oss_index_config_location
+      Dir.mkdir(@oss_index_config_location)
+      File.chmod(0o700, @oss_index_config_location)
+    end
+
+    config_path = File.join(@oss_index_config_location, @oss_index_config_filename)
+
+    # SECURITY: Write file with restrictive permissions (owner read/write only)
+    File.open(config_path, 'w', 0o600) do |file|
       file.write config.to_yaml
     end
+
+    # Ensure permissions are set even if file existed
+    File.chmod(0o600, config_path)
   end
 end

--- a/lib/chelsea/db.rb
+++ b/lib/chelsea/db.rb
@@ -16,52 +16,89 @@
 # limitations under the License.
 #
 
-require 'pstore'
+require 'json'
+require 'fileutils'
 
 module Chelsea
   # OSS Index data cache
+  # SECURITY: Uses JSON file cache instead of PStore/Marshal to prevent
+  # deserialization attacks (CVE pending - CWE-502)
   class DB
+    CACHE_TTL_HOURS = 12
+
     def initialize
-      @store = PStore.new(_get_db_store_location)
+      @cache_file = _get_db_store_location
+      _ensure_cache_directory_exists
     end
 
-    # This method will take an array of values, and save them to a pstore database
+    # This method will take an array of values, and save them to the cache
     # and as well set a TTL of Time.now to be checked later
     def save_values_to_db(values)
+      cache = _load_cache
       values.each do |val|
         next unless get_cached_value_from_db(val['coordinates']).nil?
 
         new_val = val.dup
-        new_val['ttl'] = Time.now
-        @store.transaction do
-          @store[new_val['coordinates']] = new_val
-        end
+        new_val['ttl'] = Time.now.to_i
+        cache[new_val['coordinates']] = new_val
       end
+      _save_cache(cache)
     end
 
-    # This method will delete all values in the pstore db
+    # This method will delete all values in the cache
     def clear_cache
-      @store.transaction do
-        @store.roots.each do |root|
-          @store.delete(root)
-        end
-      end
+      File.delete(@cache_file) if File.exist?(@cache_file)
     end
 
     def _get_db_store_location
       initial_path = File.join(Dir.home.to_s, '.ossindex')
-      Dir.mkdir(initial_path) unless File.exist? initial_path
-      File.join(initial_path, 'chelsea.pstore')
+      File.join(initial_path, 'chelsea-cache.json')
     end
 
-    # Checks pstore to see if a coordinate exists, and if it does also
-    # checks to see if it's ttl has expired. Returns nil unless a record
+    # Checks cache to see if a coordinate exists, and if it does also
+    # checks to see if its ttl has expired. Returns nil unless a record
     # is valid in the cache (ttl has not expired) and found
     def get_cached_value_from_db(val)
-      record = @store.transaction { @store[val] }
+      cache = _load_cache
+      record = cache[val]
       return if record.nil?
 
-      (Time.now - record['ttl']) / 3600 > 12 ? nil : record
+      ttl = record['ttl']
+      return if ttl.nil?
+
+      # Check if TTL has expired (12 hours)
+      (Time.now.to_i - ttl) / 3600 > CACHE_TTL_HOURS ? nil : record
+    end
+
+    private
+
+    def _ensure_cache_directory_exists
+      cache_dir = File.dirname(@cache_file)
+      unless File.exist?(cache_dir)
+        FileUtils.mkdir_p(cache_dir)
+        # Set restrictive permissions on directory (owner only)
+        File.chmod(0o700, cache_dir)
+      end
+    end
+
+    def _load_cache
+      return {} unless File.exist?(@cache_file)
+
+      begin
+        JSON.parse(File.read(@cache_file))
+      rescue JSON::ParserError
+        # If cache is corrupted, start fresh
+        {}
+      end
+    end
+
+    def _save_cache(cache)
+      # Write with restrictive permissions (owner read/write only)
+      File.open(@cache_file, 'w', 0o600) do |f|
+        f.write(JSON.pretty_generate(cache))
+      end
+      # Ensure permissions are set even if file existed
+      File.chmod(0o600, @cache_file)
     end
   end
 end

--- a/lib/chelsea/iq_client.rb
+++ b/lib/chelsea/iq_client.rb
@@ -26,17 +26,25 @@ require_relative 'spinner'
 module Chelsea
   # IQ audit operations
   class IQClient # rubocop:disable Metrics/ClassLength
+    # SECURITY: Removed hardcoded default credentials (CWE-798)
+    # All credentials must now be explicitly provided
     DEFAULT_OPTIONS = {
-      public_application_id: 'testapp',
-      server_url: 'http://localhost:8070',
-      username: 'admin',
-      auth_token: 'admin123',
+      public_application_id: nil,
+      server_url: nil,
+      username: nil,
+      auth_token: nil,
       internal_application_id: '',
       stage: 'build'
     }.freeze
 
-    def initialize(options: DEFAULT_OPTIONS)
-      @options = options
+    # Maximum number of polling attempts before timeout
+    MAX_POLL_RETRIES = 300
+    # Seconds to wait between poll attempts
+    POLL_INTERVAL = 1
+
+    def initialize(options: {})
+      @options = DEFAULT_OPTIONS.merge(options)
+      _validate_required_options!
       @pastel = Pastel.new
       @spinner = Chelsea::Spinner.new
     end
@@ -64,16 +72,23 @@ module Chelsea
       res['statusUrl']
     end
 
-    def poll_status(url)
+    # SECURITY: Added timeout to prevent infinite loop (CWE-835)
+    def poll_status(url) # rubocop:disable Metrics/MethodLength
       spin = @spinner.spin_msg 'Polling Nexus IQ Server for results'
+      retries = 0
       loop do
         res = _poll_iq_server(url)
         if res.code == 200
           spin.success('...done.')
           return _handle_response(res)
         end
-      rescue StandardError
-        sleep(1)
+      rescue StandardError => e
+        retries += 1
+        if retries >= MAX_POLL_RETRIES
+          spin.error('...timeout.')
+          raise "Polling timeout after #{MAX_POLL_RETRIES} attempts: #{e.message}"
+        end
+        sleep(POLL_INTERVAL)
       end
     end
 
@@ -87,6 +102,20 @@ module Chelsea
     POLICY_ACTION_NONE = 'None'
 
     private
+
+    # SECURITY: Validate required options are provided
+    def _validate_required_options!
+      missing = []
+      missing << 'server_url' if @options[:server_url].nil? || @options[:server_url].empty?
+      missing << 'username' if @options[:username].nil? || @options[:username].empty?
+      missing << 'auth_token' if @options[:auth_token].nil? || @options[:auth_token].empty?
+      missing << 'public_application_id' if @options[:public_application_id].nil? || @options[:public_application_id].empty?
+
+      return if missing.empty?
+
+      raise ArgumentError, "Missing required IQ Server options: #{missing.join(', ')}. " \
+                           'Please provide --iquser, --iqpass, --server, and --application options.'
+    end
 
     def _handle_response(res) # rubocop:disable Metrics/MethodLength
       res = JSON.parse(res.body)


### PR DESCRIPTION
## Summary

This PR addresses multiple security vulnerabilities identified in chelsea, including a **Critical Remote Code Execution** vulnerability.

### Security Fixes

| Severity | Issue | CWE | Fix |
|----------|-------|-----|-----|
| **Critical** | PStore/Marshal deserialization RCE | CWE-502 | Replaced with JSON file cache |
| **Critical** | Hardcoded default credentials (admin/admin123) | CWE-798 | Removed defaults, require explicit config |
| **High** | Insecure file permissions on config | CWE-732 | Set 0600 permissions |
| **Medium** | Infinite polling loop DoS | CWE-835 | Added timeout (300 retries max) |
| **Low** | Token visible during input | - | Masked with `noecho` |

### Breaking Changes

- IQ Server credentials (`--iquser`, `--iqpass`, `--server`, `--application`) are now **required** when using IQ features
- Cache file format changed from `.pstore` to `.json` (old cache will be ignored)

### Files Changed

- `lib/chelsea/db.rb` - Replaced PStore with secure JSON cache
- `lib/chelsea/iq_client.rb` - Removed hardcoded creds, added timeout
- `lib/chelsea/config.rb` - Added file permission restrictions

### Testing

- [ ] CI tests pass
- [ ] Manual verification of OSS Index scanning
- [ ] Manual verification of IQ Server integration (requires explicit credentials)

Fixes #49

---

Generated with [Claude Code](https://claude.ai/code)